### PR TITLE
Fix URI::build if scheme is `file`

### DIFF
--- a/src/URI.php
+++ b/src/URI.php
@@ -191,6 +191,9 @@ REGEX;
         }
 
         if (isset($components['scheme'])) {
+            if ('file' === $components['scheme']) {
+                $uri = '//' . $uri;
+            }
             return $components['scheme'] . ':' . $uri;
         }
 


### PR DESCRIPTION
Hi
if a schema $id and $ref target a local file with file scheme (ex: 'file:///an/absolute/path/to/schema.json') the Uri::build method didn't add '//' after the 'file:' (because a local file uri, obviously, doesn't have a hostname component) so the ref loader after try to load 'file:/an/absolute/path/to/schema.json', and `file_get_content` didn't accept this.

I request this little fix for this case.