### PR TITLE
Fix invalid pattern keyword exception

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1205,7 +1205,7 @@ class Validator implements IValidator
                     "'pattern' keyword must not be empty"
                 );
             }
-            $match = @preg_match('/' . $schema->pattern . '/u', $data);
+            $match = @preg_match('/' . str_replace('/', '\\/', $schema->pattern) . '/u', $data);
             if ($match === false) {
                 throw new SchemaKeywordException(
                     $schema,

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -25,6 +25,7 @@ use stdClass;
 
 class Validator implements IValidator
 {
+    private const BELL = "\x07";
 
     /** @var IValidatorHelper */
     protected $helper = null;
@@ -1205,7 +1206,7 @@ class Validator implements IValidator
                     "'pattern' keyword must not be empty"
                 );
             }
-            $match = @preg_match('/' . str_replace('/', '\\/', $schema->pattern) . '/u', $data);
+            $match = @preg_match(self::BELL . $schema->pattern . self::BELL . 'u', $data);
             if ($match === false) {
                 throw new SchemaKeywordException(
                     $schema,
@@ -1927,7 +1928,7 @@ class Validator implements IValidator
 
             $newbag = $bag->createByDiff();
             foreach ($schema->patternProperties as $pattern => &$property_schema) {
-                $regex = '/' . $pattern . '/u';
+                $regex = self::BELL . $pattern . self::BELL . 'u';
                 foreach ($properties as $name) {
                     $match = @preg_match($regex, $name);
                     if ($match === false) {

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -25,7 +25,7 @@ use stdClass;
 
 class Validator implements IValidator
 {
-    private const BELL = "\x07";
+    const BELL = "\x07";
 
     /** @var IValidatorHelper */
     protected $helper = null;

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -209,6 +209,9 @@ class TypesTest extends TestCase
         $result = $validator->uriValidation("abc", "schema:/types.json#/definitions/string/pattern");
         $this->assertTrue($result->isValid());
 
+        $result = $validator->uriValidation("abc/", "schema:/types.json#/definitions/string/pattern");
+        $this->assertTrue($result->isValid());
+
         $result = $validator->uriValidation("Abc", "schema:/types.json#/definitions/string/pattern");
         $this->assertTrue($result->hasErrors());
 

--- a/tests/schemas/types.json
+++ b/tests/schemas/types.json
@@ -46,7 +46,7 @@
             },
             "pattern": {
                 "type": "string",
-                "pattern": "^[a-z]+$"
+                "pattern": "^[a-z|/]+$"
             }
         },
         "array": {


### PR DESCRIPTION
This pull request will fix the occur of invalid pattern keyword exceptions when the used `preg_match delimeter` will be in the schema pattern property.

For example the valid pattern `^http(s)?\\://` cannot be used due to the usage of the `/` char. This will be solved with this pull request.