### PR TITLE
Fix date-time format. It accepts date times without offset now.

### DIFF
--- a/src/Formats/Time.php
+++ b/src/Formats/Time.php
@@ -21,7 +21,7 @@ class Time extends AbstractFormat
 {
 
     const REGEX = '(?<hour>[01][0-9]|2[0-3]):(?<minute>[0-5][0-9]):(?<second>[0-5][0-9]|60)(?<secfrac>\.[0-9]+)?' .
-                  '(Z|(\+|-)(?<offset_hour>[01][0-9]|2[0-3]):(?<offset_minute>[0-5][0-9]))';
+                  '(Z|(\+|-)(?<offset_hour>[01][0-9]|2[0-3]):(?<offset_minute>[0-5][0-9]))?';
 
     /**
      * @inheritDoc

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -187,6 +187,24 @@ class TypesTest extends TestCase
         $result = $validator->uriValidation("name(at)example.com", "schema:/types.json#/definitions/string/format");
         $this->assertTrue($result->hasErrors());
 
+        $result = $validator->uriValidation("1970-01-01T10:05:08", "schema:/types.json#/definitions/string/date-time");
+        $this->assertTrue($result->isValid());
+
+        $result = $validator->uriValidation("1970-01-01T10:05:08.10", "schema:/types.json#/definitions/string/date-time");
+        $this->assertTrue($result->isValid());
+
+        $result = $validator->uriValidation("1970-01-01T10:05:08+01:00", "schema:/types.json#/definitions/string/date-time");
+        $this->assertTrue($result->isValid());
+
+        $result = $validator->uriValidation("Jan. 1st, 1970 at 1 p.m.", "schema:/types.json#/definitions/string/date-time");
+        $this->assertTrue($result->hasErrors());
+
+        $result = $validator->uriValidation("1970-01-01T", "schema:/types.json#/definitions/string/date-time");
+        $this->assertTrue($result->hasErrors());
+
+        $result = $validator->uriValidation("1970-01-01", "schema:/types.json#/definitions/string/date-time");
+        $this->assertTrue($result->hasErrors());
+
         // length
 
         $result = $validator->uriValidation("AA", "schema:/types.json#/definitions/string/length");

--- a/tests/schemas/types.json
+++ b/tests/schemas/types.json
@@ -47,6 +47,10 @@
             "pattern": {
                 "type": "string",
                 "pattern": "^[a-z|/]+$"
+            },
+            "date-time": {
+                "type": "string",
+                "format": "date-time"
             }
         },
         "array": {


### PR DESCRIPTION
Following the [official documentation](https://docs.opis.io/json-schema/1.x/formats.html#date-time), the date-time format accepts:

- "1970-01-01T10:05:08"
- "1970-01-01T10:05:08.10"
- "1970-01-01T10:05:08+01:00" 

There is an issue with the [DateTime format](https://github.com/isd4n/json-schema/blob/master/src/Formats/DateTime.php). The regex is actually invalid because the offset is not optional.

This pull request includes:
- Fix to accept date times without offset
- Unitary tests for date-time (there is nothing now)