### PR TITLE
Fixes #33

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "require-dev": {
         "opis/string": "^1.4",
         "ext-bcmath": "*",
+        "ext-json": "*",
         "ext-mbstring": "*",
         "ext-intl": "*",
         "phpunit/phpunit": "^6.5"

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
     "autoload-dev": {
         "psr-4": {
             "Opis\\JsonSchema\\Test\\": "tests/"
-        }
+        },
+        "files": ["tests/functions.php"]
     },
     "extra": {
         "branch-alias": {

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -1782,7 +1782,7 @@ class Validator implements IValidator
             }
         }
 
-        $properties = array_keys(get_object_vars($data));
+        $properties = array_map('strval', array_keys(get_object_vars($data)));
 
         // minProperties
         if (property_exists($schema, 'minProperties')) {

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -18,6 +18,7 @@
 namespace Opis\JsonSchema\Test;
 
 use PHPUnit\Framework\TestCase;
+use function Opis\JsonSchema\Test\array_to_object as a2o;
 
 class TypesTest extends TestCase
 {
@@ -387,7 +388,7 @@ class TypesTest extends TestCase
     {
         $validator = $this->getValidator();
 
-        $result = $validator->uriValidation((object)[], "schema:/types.json#/definitions/object/simple");
+        $result = $validator->uriValidation(a2o([]), "schema:/types.json#/definitions/object/simple");
         $this->assertTrue($result->isValid());
 
         $result = $validator->uriValidation(null, "schema:/types.json#/definitions/object/simple");
@@ -395,140 +396,140 @@ class TypesTest extends TestCase
 
         // interval
 
-        $result = $validator->uriValidation((object)["p1" => 1, "p2" => 2], "schema:/types.json#/definitions/object/interval");
+        $result = $validator->uriValidation(a2o(["p1" => 1, "p2" => 2]), "schema:/types.json#/definitions/object/interval");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p1" => 1, "p2" => 2, "p3" => 3], "schema:/types.json#/definitions/object/interval");
+        $result = $validator->uriValidation(a2o(["p1" => 1, "p2" => 2, "p3" => 3]), "schema:/types.json#/definitions/object/interval");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p1" => 1], "schema:/types.json#/definitions/object/interval");
+        $result = $validator->uriValidation(a2o(["p1" => 1]), "schema:/types.json#/definitions/object/interval");
         $this->assertTrue($result->hasErrors());
 
-        $result = $validator->uriValidation((object)["p1" => 1, "p2" => 2, "p3" => 3, "p4" => 4], "schema:/types.json#/definitions/object/interval");
+        $result = $validator->uriValidation(a2o(["p1" => 1, "p2" => 2, "p3" => 3, "p4" => 4]), "schema:/types.json#/definitions/object/interval");
         $this->assertTrue($result->hasErrors());
 
         // required
 
-        $result = $validator->uriValidation((object)["p1" => 1, "p2" => 2], "schema:/types.json#/definitions/object/required");
+        $result = $validator->uriValidation(a2o(["p1" => 1, "p2" => 2]), "schema:/types.json#/definitions/object/required");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p1" => 1, "p2" => null, "p3" => 2], "schema:/types.json#/definitions/object/required");
+        $result = $validator->uriValidation(a2o(["p1" => 1, "p2" => null, "p3" => 2]), "schema:/types.json#/definitions/object/required");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p1" => 1], "schema:/types.json#/definitions/object/required");
+        $result = $validator->uriValidation(a2o(["p1" => 1]), "schema:/types.json#/definitions/object/required");
         $this->assertTrue($result->hasErrors());
 
         // props
 
-        $result = $validator->uriValidation((object)[], "schema:/types.json#/definitions/object/props");
+        $result = $validator->uriValidation(a2o([]), "schema:/types.json#/definitions/object/props");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p1" => 1], "schema:/types.json#/definitions/object/props");
+        $result = $validator->uriValidation(a2o(["p1" => 1]), "schema:/types.json#/definitions/object/props");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p2" => ""], "schema:/types.json#/definitions/object/props");
+        $result = $validator->uriValidation(a2o(["p2" => ""]), "schema:/types.json#/definitions/object/props");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p1" => 1, "p2" => "str"], "schema:/types.json#/definitions/object/props");
+        $result = $validator->uriValidation(a2o(["p1" => 1, "p2" => "str"]), "schema:/types.json#/definitions/object/props");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p1" => 1, "p2" => "str", "p3" => 2.5], "schema:/types.json#/definitions/object/props");
+        $result = $validator->uriValidation(a2o(["p1" => 1, "p2" => "str", "p3" => 2.5]), "schema:/types.json#/definitions/object/props");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p1" => "str", "p2" => 1], "schema:/types.json#/definitions/object/props");
+        $result = $validator->uriValidation(a2o(["p1" => "str", "p2" => 1]), "schema:/types.json#/definitions/object/props");
         $this->assertTrue($result->hasErrors());
 
-        $result = $validator->uriValidation((object)["p2" => 1], "schema:/types.json#/definitions/object/props");
+        $result = $validator->uriValidation(a2o(["p2" => 1]), "schema:/types.json#/definitions/object/props");
         $this->assertTrue($result->hasErrors());
 
-        $result = $validator->uriValidation((object)["p1" => "str"], "schema:/types.json#/definitions/object/props");
+        $result = $validator->uriValidation(a2o(["p1" => "str"]), "schema:/types.json#/definitions/object/props");
         $this->assertTrue($result->hasErrors());
 
         // props additional
 
-        $result = $validator->uriValidation((object)[], "schema:/types.json#/definitions/object/props_additional");
+        $result = $validator->uriValidation(a2o([]), "schema:/types.json#/definitions/object/props_additional");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p1" => 1], "schema:/types.json#/definitions/object/props_additional");
+        $result = $validator->uriValidation(a2o(["p1" => 1]), "schema:/types.json#/definitions/object/props_additional");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p2" => ""], "schema:/types.json#/definitions/object/props_additional");
+        $result = $validator->uriValidation(a2o(["p2" => ""]), "schema:/types.json#/definitions/object/props_additional");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p1" => 1, "p2" => "str"], "schema:/types.json#/definitions/object/props_additional");
+        $result = $validator->uriValidation(a2o(["p1" => 1, "p2" => "str"]), "schema:/types.json#/definitions/object/props_additional");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p1" => 1, "p2" => "str", "p5" => null], "schema:/types.json#/definitions/object/props_additional");
+        $result = $validator->uriValidation(a2o(["p1" => 1, "p2" => "str", "p5" => null]), "schema:/types.json#/definitions/object/props_additional");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["other" => null], "schema:/types.json#/definitions/object/props_additional");
+        $result = $validator->uriValidation(a2o(["other" => null]), "schema:/types.json#/definitions/object/props_additional");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p1" => 1, "p2" => "str", "other" => false], "schema:/types.json#/definitions/object/props_additional");
+        $result = $validator->uriValidation(a2o(["p1" => 1, "p2" => "str", "other" => false]), "schema:/types.json#/definitions/object/props_additional");
         $this->assertTrue($result->hasErrors());
 
         // pattern (propertyNames)
 
-        $result = $validator->uriValidation((object)[], "schema:/types.json#/definitions/object/pattern");
+        $result = $validator->uriValidation(a2o([]), "schema:/types.json#/definitions/object/pattern");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["prop" => 1], "schema:/types.json#/definitions/object/pattern");
+        $result = $validator->uriValidation(a2o(["prop" => 1]), "schema:/types.json#/definitions/object/pattern");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p1" => 5], "schema:/types.json#/definitions/object/pattern");
+        $result = $validator->uriValidation(a2o(["p1" => 5]), "schema:/types.json#/definitions/object/pattern");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p8" => "str"], "schema:/types.json#/definitions/object/pattern");
+        $result = $validator->uriValidation(a2o(["p8" => "str"]), "schema:/types.json#/definitions/object/pattern");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p5" => -3.2, "p6" => "str"], "schema:/types.json#/definitions/object/pattern");
+        $result = $validator->uriValidation(a2o(["p5" => -3.2, "p6" => "str"]), "schema:/types.json#/definitions/object/pattern");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p34" => false], "schema:/types.json#/definitions/object/pattern");
+        $result = $validator->uriValidation(a2o(["p34" => false]), "schema:/types.json#/definitions/object/pattern");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)["p3" => "5"], "schema:/types.json#/definitions/object/pattern");
+        $result = $validator->uriValidation(a2o(["p3" => "5"]), "schema:/types.json#/definitions/object/pattern");
         $this->assertTrue($result->hasErrors());
 
-        $result = $validator->uriValidation((object)["p0" => 1], "schema:/types.json#/definitions/object/pattern");
+        $result = $validator->uriValidation(a2o(["p0" => 1]), "schema:/types.json#/definitions/object/pattern");
         $this->assertTrue($result->hasErrors());
 
-        $result = $validator->uriValidation(json_decode('{"12345": 0, "0": "something"}'), "schema:/types.json#/definitions/object/prop_names_numeric");
+        $result = $validator->uriValidation(a2o(["12345" => 0, "0" => "something"]), "schema:/types.json#/definitions/object/prop_names_numeric");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation(json_decode('{"-12345": true, "1offender": "false"}'), "schema:/types.json#/definitions/object/prop_names_numeric");
+        $result = $validator->uriValidation(a2o(["-12345" => true, "1offender" => "false"]), "schema:/types.json#/definitions/object/prop_names_numeric");
         $this->assertTrue($result->hasErrors());
 
-        $result = $validator->uriValidation(json_decode('{"noNumbersHere": true}'), "schema:/types.json#/definitions/object/prop_names_numeric");
+        $result = $validator->uriValidation(a2o(["noNumbersHere" => true]), "schema:/types.json#/definitions/object/prop_names_numeric");
         $this->assertTrue($result->hasErrors());
 
         // dep
 
-        $result = $validator->uriValidation((object)[], "schema:/types.json#/definitions/object/dep");
+        $result = $validator->uriValidation(a2o([]), "schema:/types.json#/definitions/object/dep");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)['e' => 1, 'a' => [1, 2], 'b' => null], "schema:/types.json#/definitions/object/dep");
+        $result = $validator->uriValidation(a2o(['e' => 1, 'a' => [1, 2], 'b' => null]), "schema:/types.json#/definitions/object/dep");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)['e' => 1, 'a' => [1, 2]], "schema:/types.json#/definitions/object/dep");
+        $result = $validator->uriValidation(a2o(['e' => 1, 'a' => [1, 2]]), "schema:/types.json#/definitions/object/dep");
         $this->assertTrue($result->hasErrors());
 
-        $result = $validator->uriValidation((object)['e' => 1, 'a' => 1, 'b' => 2], "schema:/types.json#/definitions/object/dep");
+        $result = $validator->uriValidation(a2o(['e' => 1, 'a' => 1, 'b' => 2]), "schema:/types.json#/definitions/object/dep");
         $this->assertTrue($result->hasErrors());
 
-        $result = $validator->uriValidation((object)['a' => 1, 'b' => 2], "schema:/types.json#/definitions/object/dep");
+        $result = $validator->uriValidation(a2o(['a' => 1, 'b' => 2]), "schema:/types.json#/definitions/object/dep");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)['c' => 1, 'd' => 2], "schema:/types.json#/definitions/object/dep");
+        $result = $validator->uriValidation(a2o(['c' => 1, 'd' => 2]), "schema:/types.json#/definitions/object/dep");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)['b' => 1, 'd' => 2], "schema:/types.json#/definitions/object/dep");
+        $result = $validator->uriValidation(a2o(['b' => 1, 'd' => 2]), "schema:/types.json#/definitions/object/dep");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)['a' => 'str'], "schema:/types.json#/definitions/object/dep");
+        $result = $validator->uriValidation(a2o(['a' => 'str']), "schema:/types.json#/definitions/object/dep");
         $this->assertTrue($result->hasErrors());
 
-        $result = $validator->uriValidation((object)['c' => 1], "schema:/types.json#/definitions/object/dep");
+        $result = $validator->uriValidation(a2o(['c' => 1]), "schema:/types.json#/definitions/object/dep");
         $this->assertTrue($result->hasErrors());
 
     }
@@ -549,7 +550,7 @@ class TypesTest extends TestCase
         $result = $validator->uriValidation([1, 2, 3], "schema:/types.json#/definitions/combined");
         $this->assertTrue($result->isValid());
 
-        $result = $validator->uriValidation((object)['a' => null], "schema:/types.json#/definitions/combined");
+        $result = $validator->uriValidation(a2o(['a' => null]), "schema:/types.json#/definitions/combined");
         $this->assertTrue($result->isValid());
 
         $result = $validator->uriValidation(null, "schema:/types.json#/definitions/combined");
@@ -564,7 +565,7 @@ class TypesTest extends TestCase
         $result = $validator->uriValidation([1, 2], "schema:/types.json#/definitions/combined");
         $this->assertTrue($result->hasErrors());
 
-        $result = $validator->uriValidation((object)['b' => ''], "schema:/types.json#/definitions/combined");
+        $result = $validator->uriValidation(a2o(['b' => '']), "schema:/types.json#/definitions/combined");
         $this->assertTrue($result->hasErrors());
 
     }

--- a/tests/TypesTest.php
+++ b/tests/TypesTest.php
@@ -493,6 +493,15 @@ class TypesTest extends TestCase
         $result = $validator->uriValidation((object)["p0" => 1], "schema:/types.json#/definitions/object/pattern");
         $this->assertTrue($result->hasErrors());
 
+        $result = $validator->uriValidation(json_decode('{"12345": 0, "0": "something"}'), "schema:/types.json#/definitions/object/prop_names_numeric");
+        $this->assertTrue($result->isValid());
+
+        $result = $validator->uriValidation(json_decode('{"-12345": true, "1offender": "false"}'), "schema:/types.json#/definitions/object/prop_names_numeric");
+        $this->assertTrue($result->hasErrors());
+
+        $result = $validator->uriValidation(json_decode('{"noNumbersHere": true}'), "schema:/types.json#/definitions/object/prop_names_numeric");
+        $this->assertTrue($result->hasErrors());
+
         // dep
 
         $result = $validator->uriValidation((object)[], "schema:/types.json#/definitions/object/dep");

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Opis\JsonSchema\Test;
+
+function array_to_object(array $source): \stdClass {
+    return json_decode(json_encode((object)$source));
+}

--- a/tests/schemas/types.json
+++ b/tests/schemas/types.json
@@ -138,6 +138,13 @@
                     "^p[02468]$": {"type": "string"}
                 }
             },
+            "prop_names_numeric": {
+                "type": "object",
+                "propertyNames": {
+                    "type": "string",
+                    "pattern": "^(0|-?[1-9][0-9]*)$"
+                }
+            },
             "dep": {
                 "type": "object",
                 "dependencies": {


### PR DESCRIPTION
> Object property names are expected to be strings, while integer-like names are converted to integers in the return value of get_object_vars(), due to PHP arrays'
specifics, and string-related keywords are not applied. So force them back to strings.

Please double-check my logic. Sorry for possibly excessive impulsivity, too excited about my first contribution^^'

The commit passes the phpunit tests, and my
<details><summary>homemade test based on #33 samples</summary>

```php
<?php

require_once __DIR__.'/vendor/autoload.php';

use Opis\JsonSchema\Validator;

function strPassFail(bool $isOk) : string
{
    return $isOk ? 'PASS' : 'FAIL';
}

function testWithData(string $schema, array $cases)
{

    print("Schema: $schema\n\n");

    foreach($cases as $index => $caseParams) {

        list ($json, $expectedValid) = $caseParams;

        $validator = new Validator();
        $data = json_decode($json);
        if (json_last_error() !== JSON_ERROR_NONE) {
            throw new RuntimeException('Bad JSON');
        }
        $result = $validator->dataValidation($data, $schema);
        $actualValid = $result->isValid();

        $expectedValid = strPassFail($expectedValid);
        $actualValid = strPassFail($actualValid);
        $indicator = $expectedValid === $actualValid ? '+' : '-';
        print("$indicator $expectedValid $actualValid $index $json\n");
    }

    print("\n");

}

testWithData(
    '{"propertyNames": { "pattern": "^[a-z]{3}$" }}',
    [
        ['{"aaa": 0}', true],
        ['{"aaaa": 0}', false],
        ['{"ab": 0}', false],
        ['{"123": 0}', false],
        ['{"123456789": 0}', false],
    ]
);

testWithData(
    '{"propertyNames": { "pattern": "^(0?[1-9]|1[0-6])$" }}',
    [
        ['{"aaa": 1}', false],
        ['{"aaaa": 1}', false],
        ['{"aa": 1}', false],
        ['{"10": 1}', true],
        ['{"123": 0}', false],
        ['{"123456789": 0}', false],
    ]
);

print("Done.\n");
```
</details>

Additional suggestions:
 - add test cases for integer-like property names;
 - switch test data samples from `(object)[...]` to `json_decode('{...}')`, because there is the same trick there, with integer-like property names.