### PR TITLE
Feature: uuid string format

### DIFF
--- a/src/FormatContainer.php
+++ b/src/FormatContainer.php
@@ -40,6 +40,7 @@ class FormatContainer implements IFormatContainer
             'uri-template' => Formats\UriTemplate::class,
             'iri' => Formats\Iri::class,
             'iri-reference' => Formats\IriReference::class,
+            'uuid' => Formats\Uuid::class,
         ]
     ];
 

--- a/src/Formats/Uuid.php
+++ b/src/Formats/Uuid.php
@@ -1,0 +1,34 @@
+<?php
+/* ===========================================================================
+ * Copyright 2018 Zindex Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ============================================================================ */
+
+namespace Opis\JsonSchema\Formats;
+
+class Uuid extends AbstractFormat
+{
+    /**
+     * Regular expression that matches RFC 4122 compliant UUIDs.
+     */
+    const UUID_REGEX = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
+
+    /**
+     * @inheritDoc
+     */
+    public function validate($data): bool
+    {
+        return $this->validateRegex($data, self::UUID_REGEX);
+    }
+}

--- a/tests/official/tests/draft7/optional/format/uuid.json
+++ b/tests/official/tests/draft7/optional/format/uuid.json
@@ -1,0 +1,23 @@
+[
+    {
+        "description": "validation of uuid values",
+        "schema": {"format": "uuid"},
+        "tests": [
+            {
+                "description": "a valid uuid string",
+                "data": "a175112a-1043-4344-80ec-2deb09cb615e",
+                "valid": true
+            },
+            {
+                "description": "a valid uppercase uuid string",
+                "data": "A175112A-1043-4344-80EC-2DEB09CB615E",
+                "valid": true
+            },
+            {
+                "description": "an invalid uuid string",
+                "data": "a175112a-1043-4344-80ec",
+                "valid": false
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Back [in February](https://github.com/json-schema-org/json-schema-spec/pull/715) the `uuid` string format was added to the latest, yet unreleased version of the json-schema specification.

That'd be very useful to us.