### PR TITLE
Added __toString to ValidationResult and ValidationError so they can be

### DIFF
--- a/src/ValidationError.php
+++ b/src/ValidationError.php
@@ -137,4 +137,42 @@ final class ValidationError
     {
         return count($this->subErrors);
     }
+
+    /**
+     * @return bool
+     */
+    public function hasSubErrors(): bool
+    {
+        return $this->subErrorsCount() > 0;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return array(
+            'data' => $this->data(),
+            'dataPointer' => $this->dataPointer(),
+            'keywordArgs' => $this->keywordArgs(),
+            'hasSubErrors' => $this->hasSubErrors(),
+            'subErrors' => $this->subErrors()
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function toJson(): string
+    {
+        return (string)json_encode($this->toArray());
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->toJson();
+    }
 }

--- a/src/ValidationResult.php
+++ b/src/ValidationResult.php
@@ -136,4 +136,43 @@ final class ValidationResult
         }
         return new self($max);
     }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return array(
+            'hasErrors' => $this->hasErrors(),
+            'errors' => $this->getErrorsAsArray(),
+            'maxErrors' => $this->maxErrors(),
+            'totalErrors' => $this->totalErrors()
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function toJson(): string
+    {
+        return (string)json_encode($this->toArray());
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->toJson();
+    }
+
+    /**
+     * @return array
+     */
+    private function getErrorsAsArray(): array
+    {
+        return array_map(static function (ValidationError $error){
+            return $error->toArray();
+        }, $this->getErrors());
+    }
 }

--- a/tests/ValidationErrorTest.php
+++ b/tests/ValidationErrorTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Opis\JsonSchema\Test;
+
+use Opis\JsonSchema\IValidator;
+use Opis\JsonSchema\ValidationResult;
+use PHPUnit\Framework\TestCase;
+
+class ValidationErrorTest extends TestCase
+{
+    use JsonValidatorTrait;
+
+    /** @var IValidator */
+    protected $validator;
+
+    public function getValidator(): IValidator
+    {
+        return $this->validator;
+    }
+
+    public function test_hasSubErrors_withNoSubErrors_isFalse()
+    {
+        $actual = $this->uriValidation('a')->getFirstError()->hasSubErrors();
+
+        $this->assertFalse($actual);
+    }
+
+    public function test__toString_withOneError_isValidJson()
+    {
+        $expected = '{"data": "a", "dataPointer": [], "keywordArgs": {"expected": 10}, "hasSubErrors": false, "subErrors": []}';
+        $actual = (string)$this->uriValidation('a')->getFirstError();
+
+        $this->assertJsonStringEqualsJsonString($expected, $actual);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->validator = $this->createValidator();
+    }
+
+    /**
+     * @param mixed $data
+     *
+     * @return ValidationResult
+     */
+    private function uriValidation($data): ValidationResult
+    {
+        return $this->getValidator()->uriValidation($data, 'schema:/basic.json#/definitions/constant');
+    }
+}

--- a/tests/ValidationResultTest.php
+++ b/tests/ValidationResultTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace Opis\JsonSchema\Test;
+
+use Opis\JsonSchema\IValidator;
+use Opis\JsonSchema\ValidationResult;
+use PHPUnit\Framework\TestCase;
+
+class ValidationResultTest extends TestCase
+{
+    use JsonValidatorTrait;
+
+    /** @var IValidator */
+    protected $validator;
+
+    public function getValidator(): IValidator
+    {
+        return $this->validator;
+    }
+
+    public function test__toString_withoutErrors_isValidJson()
+    {
+        $expected = '{"hasErrors": false, "errors": [], "maxErrors": 1, "totalErrors": 0}';
+        $actual = (string)$this->uriValidation(10);
+
+        $this->assertJsonStringEqualsJsonString($expected, $actual);
+    }
+
+    public function test__toString_withOneError_isValidJson()
+    {
+        $expected = <<<'JSON'
+{
+  "hasErrors": true,
+  "errors": [
+    {
+      "data": "a",
+      "dataPointer": [],
+      "keywordArgs": {
+        "expected": 10
+      },
+      "hasSubErrors": false,
+      "subErrors": []
+    }
+  ],
+  "maxErrors": 1,
+  "totalErrors": 1
+}
+JSON;
+        $actual = (string)$this->uriValidation('a');
+
+        $this->assertJsonStringEqualsJsonString($expected, $actual);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->validator = $this->createValidator();
+    }
+
+    /**
+     * @param mixed $data
+     *
+     * @return ValidationResult
+     */
+    private function uriValidation($data): ValidationResult
+    {
+        return $this->getValidator()->uriValidation($data, 'schema:/basic.json#/definitions/constant');
+    }
+}


### PR DESCRIPTION
Added __toString to ValidationResult and ValidationError so they can be they can be more easily used for a response to a (failed) validation request:

```php
$validator = new \Opis\JsonSchema\Validator();
$result = $validator->schemaValidation($json, $schema);

if (!($result->isValid())) {
    $this->logger->info($result);
    header('Content-Type: application/json');
    die($result);
}
```