### PR TITLE
Allow to load a fragment through an ILoader

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -405,6 +405,23 @@ class Validator implements IValidator
             unset($pointer);
         }
 
+        // Check if we can find the fragment through the loader
+        if ($this->loader !== null) {
+            $fragmentDocument = $this->loader->loadSchema($ref);
+            if ($fragmentDocument) {
+                if (!$map_used) {
+                    unset($document_data);
+                    $document_data = &$data;
+                    if ($data_pointer) {
+                        $parent_data_pointer = array_merge($parent_data_pointer, $data_pointer);
+                        $data_pointer = [];
+                    }
+                }
+
+                return $this->validateSchema($document_data, $data, $data_pointer, $parent_data_pointer, $fragmentDocument, $fragmentDocument->resolve(), $bag);
+            }
+        }
+
         // Merge uris
         $ref = URI::merge($ref, $schema->{Schema::BASE_ID_PROP} ?? '', true);
 


### PR DESCRIPTION
Not sure if this would be useful in your repo, but I have an implementation using the opis/json-schema that allows to adjust schemas. After it's been adjusted the `ILoader` caches that version, so that subsequent loads use the adjusted/enhanced schema when it's referenced somewhere instead of fetching the fragment from the source/parent schema.

Therefore I had to hook into the `validateRef()` function to check if the fragment being `$refs`-ed can be provided by the `ILoader` (who in my case can return the enhanced version from cache) before the `validateRef()` function is fetching it via the `JsonPointer::getDataByPointer()`.

If you think this is something that the package should support, feel free to use this patch. I'm also glad to elaborate on it if requested.  