### PR TITLE
Helper::convertAssocArrayToObject(): Fix recursion for nested arrays, add tests

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -147,8 +147,8 @@ final class Helper
 
     /**
      * Converts assoc-arrays to objects (recursive)
-     * @param $schema
-     * @return mixed
+     * @param scalar|\stdClass|array $schema
+     * @return scalar|\stdClass|array
      */
     public static function convertAssocArrayToObject($schema)
     {
@@ -161,7 +161,7 @@ final class Helper
         $data = [];
 
         foreach ($schema as $key => $value) {
-            $data[$key] = is_array($value) || is_object($value) ? self::convertAssocArrayToObject($schema) : $value;
+            $data[$key] = is_array($value) || is_object($value) ? self::convertAssocArrayToObject($value) : $value;
         }
 
         return $keepArray ? $data : (object) $data;

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Opis\JsonSchema\Test;
+
+use Opis\JsonSchema\Helper;
+use PHPUnit\Framework\TestCase;
+
+class HelperTest extends TestCase
+{
+    public function testConvertAssocArrayToObject()
+    {
+        $object = Helper::convertAssocArrayToObject(['a' => ['b' => ['c' => 'd']]]);
+        $this->assertSame('d', $object->a->b->c);
+    }
+
+    public function testConvertAssocArrayWithObjectToObject()
+    {
+        $object = Helper::convertAssocArrayToObject(['a' => (object) ['b' => ['c' => 'd']]]);
+        $this->assertSame('d', $object->a->b->c);
+    }
+
+    public function testConvertAssocArrayWithIndexedArrayToObject()
+    {
+        $object = Helper::convertAssocArrayToObject(['a' => ['b', ['c' => 'd']]]);
+        $this->assertSame('b', $object->a[0]);
+        $this->assertSame('d', $object->a[1]->c);
+    }
+
+      public function testConvertAssocArrayToObjectWithScalar()
+    {
+        $this->assertNull(Helper::convertAssocArrayToObject(null));
+        $this->assertSame(2, Helper::convertAssocArrayToObject(2));
+        $this->assertSame('foo', Helper::convertAssocArrayToObject('foo'));
+        $this->assertSame(true, Helper::convertAssocArrayToObject(true));
+    }
+}


### PR DESCRIPTION
Currently, calling `Helper::convertAssocArrayToObject()` with a nested array e.g. `['a' => ['b' => 'c']]` causes an out of memory error, because the wrong variable is used in the recursion.

This PR fixes that and introduces tests for the rest of the method. As far as I can tell, the method was previously untested.