### PR TITLE
Correctly cast object to boolean, added more tests

### DIFF
--- a/src/Pragmas/CastPragma.php
+++ b/src/Pragmas/CastPragma.php
@@ -191,7 +191,7 @@ class CastPragma implements Pragma
             return !($value === '');
         }
         if (is_object($value)) {
-            return count(get_object_vars($value)) === 0;
+            return count(get_object_vars($value)) > 0;
         }
         return boolval($value);
     }

--- a/tests/PragmaTest.php
+++ b/tests/PragmaTest.php
@@ -35,26 +35,127 @@ class PragmaTest extends AbstractTest
             // slots
             ["{$schema}/testSlots", 1, true],
             ["{$schema}/testSlots", "str", false],
-            // cast
+
+            // cast integers
             ["{$schema}/testCastInteger", 1.2, true],
+            ["{$schema}/testCastInteger", "not_an_integer", true],
+            ["{$schema}/testCastInteger", "also not integer", true],
+            ["{$schema}/testCastInteger", "1212", true],
+            ["{$schema}/testCastInteger", "1", true],
+            ["{$schema}/testCastInteger", 1, true],
+            ["{$schema}/testCastInteger", 0, true],
             ["{$schema}/testCastInteger", "-123.4567", true],
             ["{$schema}/testCastInteger", null, true],
+            // array/object become null
             ["{$schema}/testCastInteger", [], false],
+            ["{$schema}/testCastInteger", (object)[], false],
 
-            ["{$schema}/testCastNumber", 1.2, true],
-            ["{$schema}/testCastNumber", "-123.4567", true],
+            // pass minimum after cast
+            ["{$schema}/testCastIntegerMinimum1", 1.2, true],
+            ["{$schema}/testCastIntegerMinimum1", 1, true],
+
+            // fail minimum after cast
+            ["{$schema}/testCastIntegerMinimum1", "also not integer", false],
+            ["{$schema}/testCastIntegerMinimum1", "0", false],
+            ["{$schema}/testCastIntegerMinimum1", null, false],
+            ["{$schema}/testCastIntegerMinimum1", "-123.4567", false],
+            ["{$schema}/testCastIntegerMinimum1", 0, false],
+
+            // Max integer fail
+            ["{$schema}/testCastIntegerMaximum0", "1", false],
+            ["{$schema}/testCastIntegerMaximum0", "123.23", false],
+
+            // Pass number cast, no min/max; strings and null become 0
+            ["{$schema}/testCastNumber", "not a number", true],
+            ["{$schema}/testCastNumber", "also not a number", true],
             ["{$schema}/testCastNumber", null, true],
+            ["{$schema}/testCastNumber", 0, true],
+            ["{$schema}/testCastNumber", "-123.4567", true],
+            // array/object become null
+            ["{$schema}/testCastNumber", [], false],
+            ["{$schema}/testCastNumber", (object)[], false],
 
+            // pass minimum after cast
+            ["{$schema}/testCastNumberMinimum1", 1.2, true],
+            ["{$schema}/testCastNumberMinimum1", 1, true],
+            ["{$schema}/testCastNumberMinimum1", "1.1", true],
+
+            // fail minimum after cast
+            ["{$schema}/testCastNumberMinimum1", "also not number", false],
+            ["{$schema}/testCastNumberMinimum1", "0", false],
+            ["{$schema}/testCastNumberMinimum1", 0, false],
+            ["{$schema}/testCastNumberMinimum1", "-123.4567", false],
+
+            // Max number fail
+            ["{$schema}/testCastNumberMaximum0", "1", false],
+            ["{$schema}/testCastNumberMaximum0", "123.4567", false],
+
+            ["{$schema}/testCastString", 1, true],
             ["{$schema}/testCastString", 1.2, true],
+            ["{$schema}/testCastString", true, true],
+            ["{$schema}/testCastString", false, true],
+            ["{$schema}/testCastString", null, true],
+            // string cannot be cast to array or object, regardless if empty
             ["{$schema}/testCastString", [], false],
+            ["{$schema}/testCastString", ["non-empty array"], false],
+            ["{$schema}/testCastString", (object)[], false],
             ["{$schema}/testCastString", (object)['a' => 1], false],
 
+            // Everything can be cast to array
             ["{$schema}/testCastArray", 1.2, true],
+            ["{$schema}/testCastArray", null, true],
+            ["{$schema}/testCastArray", false, true],
+            ["{$schema}/testCastArray", true, true],
             ["{$schema}/testCastArray", [1, 2], true],
             ["{$schema}/testCastArray", [1, "4"], true],
             ["{$schema}/testCastArray", (object)["a" => 1, "b" => 2.5, "c" => "123"], true],
 
+            // Objects can only be cast to arrays, everything else fails
             ["{$schema}/testCastObject", ["a" => 1, "b" => 2], true],
+            ["{$schema}/testCastObject", 1, false],
+            ["{$schema}/testCastObject", 1.2, false],
+            ["{$schema}/testCastObject", -1.2, false],
+            ["{$schema}/testCastObject", "1", false],
+            ["{$schema}/testCastObject", "", false],
+            ["{$schema}/testCastObject", true, false],
+            ["{$schema}/testCastObject", false, false],
+            ["{$schema}/testCastObject", null, false],
+
+            // Boolean casts that give true
+            ["{$schema}/testCastBooleanTrue", true, true],
+            ["{$schema}/testCastBooleanTrue", 1.0, true],
+            ["{$schema}/testCastBooleanTrue", 0.1, true],
+            ["{$schema}/testCastBooleanTrue", -0.1, true],
+            ["{$schema}/testCastBooleanTrue", "-0", true],
+            ["{$schema}/testCastBooleanTrue", ["test"], true],
+            ["{$schema}/testCastBooleanTrue", (object)["a" => 1, "b" => 2.5, "c" => "123"], true],
+
+            // Boolean casts that give false
+            ["{$schema}/testCastBooleanFalse", false, true],
+            ["{$schema}/testCastBooleanFalse", "", true],
+            ["{$schema}/testCastBooleanFalse", 0, true],
+            ["{$schema}/testCastBooleanFalse", -0, true],
+            ["{$schema}/testCastBooleanFalse", null, true],
+            ["{$schema}/testCastBooleanFalse", [], true],
+            ["{$schema}/testCastBooleanFalse", (object)[], true],
+
+            // Integer, number, string and bool to object => null
+            ["{$schema}/testCastObjectNull", 123, true],
+            ["{$schema}/testCastObjectNull", 123.123, true],
+            ["{$schema}/testCastObjectNull", "string", true],
+            ["{$schema}/testCastObjectNull", true, true],
+            ["{$schema}/testCastObjectNull", false, true],
+
+            // Array to string, number, integer => null
+            ["{$schema}/testCastStringNull", [], true],
+            ["{$schema}/testCastNumberNull", [], true],
+            ["{$schema}/testCastIntegerNull", [], true],
+
+            // Object to string, number, integer => null
+            ["{$schema}/testCastStringNull", (object)[], true],
+            ["{$schema}/testCastNumberNull", (object)[], true],
+            ["{$schema}/testCastIntegerNull", (object)[], true],
+
         ];
     }
 }

--- a/tests/schemas/pragma.json
+++ b/tests/schemas/pragma.json
@@ -40,11 +40,81 @@
             },
             "type": "integer"
         },
+        "testCastObjectNull": {
+            "$pragma": {
+                "cast": "object"
+            },
+            "type": ["object", "null"],
+            "const": null
+        },
+        "testCastStringNull": {
+            "$pragma": {
+                "cast": "string"
+            },
+            "type": ["string", "null"],
+            "const": null
+        },
+        "testCastIntegerNull": {
+            "$pragma": {
+                "cast": "integer"
+            },
+            "type": ["integer", "null"],
+            "const": null
+        },
+        "testCastNumberNull": {
+            "$pragma": {
+                "cast": "number"
+            },
+            "type": ["number", "null"],
+            "const": null
+        },
+        "testCastBooleanTrue": {
+            "$pragma": {
+                "cast": "boolean"
+            },
+            "type": "boolean",
+            "const": true
+        },
+        "testCastBooleanFalse": {
+            "$pragma": {
+              "cast": "boolean"
+            },
+            "type": "boolean",
+            "const": false
+        },
+        "testCastIntegerMinimum1": {
+            "$pragma": {
+                "cast": "integer"
+            },
+            "type": "integer",
+            "minimum": 1
+        },
+        "testCastIntegerMaximum0": {
+            "$pragma": {
+              "cast": "integer"
+            },
+            "type": "integer",
+            "maximum": 0
+        },
         "testCastNumber": {
             "$pragma": {
                 "cast": "number"
             },
             "type": "number"
+        },
+        "testCastNumberMinimum1": {
+            "$pragma": {
+                "cast": "number"
+            },
+            "type": "number",
+            "minimum": 1
+        },
+       "testCastNumberMaximum0": {
+            "$pragma": {
+              "cast": "number"
+            },
+            "type": "number",
+            "maximum": 0
         },
         "testCastString": {
             "$pragma": {


### PR DESCRIPTION
Hello

After my issue (https://github.com/opis/json-schema/issues/81) I worked out this. I am unsure if the reason you accept strings that are clearly not numbers is simply because you want to mimic PHPs odd handling of numeric strings (i.e. `144 === (int)"144 sf_sdfsdf"`). 

I also fixed a bug related to objects incorrectly converted to boolean (I don't know why anyone would use this cast though). It was inverted based on the documentation.

None of this solves the problem with the data not actually being cast.