### PR TITLE
Remove Deprecated for PHP 8.1

### DIFF
--- a/src/Errors/ErrorContainer.php
+++ b/src/Errors/ErrorContainer.php
@@ -115,6 +115,7 @@ class ErrorContainer implements Countable, Iterator
     /**
      * @inheritDoc
      */
+    #[\ReturnTypeWillChange]
     public function next(): ?ValidationError
     {
         return next($this->errors) ?: null;
@@ -139,6 +140,7 @@ class ErrorContainer implements Countable, Iterator
     /**
      * @inheritDoc
      */
+    #[\ReturnTypeWillChange]
     public function rewind(): ?ValidationError
     {
         return reset($this->errors) ?: null;


### PR DESCRIPTION
Add PHP Attribute `ReturnTypeWillChange` on ErrorContainer::next and ErrorContainer::rewind to temporarily suppress the deprecation notices: 
- `Deprecated: Return type of Opis\JsonSchema\Errors\ErrorContainer::next(): ?Opis\JsonSchema\Errors\ValidationError should either be compatible with Iterator::next(): void`
- `Deprecated: Return type of Opis\JsonSchema\Errors\ErrorContainer::rewind(): ?Opis\JsonSchema\Errors\ValidationError should either be compatible with Iterator::rewind(): void`.

Replacing the return types to be compatible with internal `Iterator` PHP classes will be a BC Break, but it has to change to remove those PHP Attributes and be ready for PHP 9.0.