### PR TITLE
Fix keyword name maxContains

### DIFF
--- a/src/Keywords/ContainsKeyword.php
+++ b/src/Keywords/ContainsKeyword.php
@@ -127,7 +127,7 @@ class ContainsKeyword implements Keyword
         }
 
         if (!$isMaxNull && $valid > $this->max) {
-            return $this->error($schema, $context, 'minContains', 'At most {max} array items must match schema', [
+            return $this->error($schema, $context, 'maxContains', 'At most {max} array items must match schema', [
                 'max' => $this->max,
                 'count' => $valid,
             ]);


### PR DESCRIPTION
Fix typo for keyword name `maxContains` error.