### PR TITLE
Handle hyphen suffixed e-mail names

### DIFF
--- a/src/Formats/IriFormats.php
+++ b/src/Formats/IriFormats.php
@@ -96,7 +96,10 @@ class IriFormats
                 return false;
             }
 
-            $m['name'] = $idn($m['name']);
+            // E-mail address names are allowed to end in one or more hyphens.
+            // This is, however, not supported by the $idn callback, which will
+            // fail in that case.
+            $m['name'] = $idn(rtrim($m['name'], '-'));
             if ($m['name'] === null) {
                 return false;
             }

--- a/tests/official/tests/draft07/optional/format/idn-email.json
+++ b/tests/official/tests/draft07/optional/format/idn-email.json
@@ -22,6 +22,11 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "a valid e-mail address with hyphen suffixed name",
+                "data": "hyphened--email---@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/official/tests/draft2019-09/optional/format/idn-email.json
+++ b/tests/official/tests/draft2019-09/optional/format/idn-email.json
@@ -22,6 +22,11 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "a valid e-mail address with hyphen suffixed name",
+                "data": "hyphened--email---@example.com",
+                "valid": true
             }
         ]
     }

--- a/tests/official/tests/draft2020-12/optional/format/idn-email.json
+++ b/tests/official/tests/draft2020-12/optional/format/idn-email.json
@@ -22,6 +22,11 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "a valid e-mail address with hyphen suffixed name",
+                "data": "hyphened--email---@example.com",
+                "valid": true
             }
         ]
     }


### PR DESCRIPTION
We're currently having issues with the validator due to e-mail addresses like the following are being rejected:
```
hyphened--email---@example.com
```
These e-mail addresses are, however, completely valid, so the validator should be able to recognize them as such.

The incorrect rejection is apparently due to `idn_to_ascii()` not being able to handle values ending in one or more hyphens, but this (quick) fix should circumvent that.
