### PR TITLE
Add PHP 8.2 to tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 8.0, 8.1]
+        php: [7.4, 8.0, 8.1, 8.2]
 
     name: PHP ${{ matrix.php }}
 


### PR DESCRIPTION
PHP 8.2 is the current relevant version, let's make sure the library works there.
