### PR TITLE
Fix: stop `AdditionalPropertiesKeyword` from throwing incorrect errors #148

### DIFF
--- a/src/Keywords/PropertiesKeyword.php
+++ b/src/Keywords/PropertiesKeyword.php
@@ -93,6 +93,7 @@ class PropertiesKeyword implements Keyword
             }
         }
 
+        $context->addCheckedProperties($checked);
         $context->addEvaluatedProperties($evaluated);
 
         if (!$errors->isEmpty()) {
@@ -101,8 +102,6 @@ class PropertiesKeyword implements Keyword
             ], $errors);
         }
         unset($errors);
-
-        $context->addCheckedProperties($checked);
 
         return null;
     }


### PR DESCRIPTION
This commit prevents `Opis\JsonSchema\Keywords\AdditionalPropertiesKeyword` from throwing incorrect errors when the data is invalid.

To prevent erroneous invalidation, it checks the properties that have been defined in the current schema and removes them from the unchecked properties array.

This commit resolves #148