### PR TITLE
PHP 8.5 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
 
     name: PHP ${{ matrix.php }}
 

--- a/src/SchemaLoader.php
+++ b/src/SchemaLoader.php
@@ -242,7 +242,7 @@ class SchemaLoader
      */
     protected function checkExistingObject(object $data): ?Schema
     {
-        if (!$this->dataCache->contains($data)) {
+        if (!$this->dataCache->offsetExists($data)) {
             return null;
         }
 


### PR DESCRIPTION
Ensures PHP 8.5 compatibility by replacing [`SplObjectStorage::contains()`](https://www.php.net/manual/en/splobjectstorage.contains.php) call with [`SplObjectStorage::offsetExists()`](https://www.php.net/manual/en/splobjectstorage.offsetexists.php)