### PR TITLE
Remove deprecations in exceptions

### DIFF
--- a/src/Exception/DuplicateSchemaException.php
+++ b/src/Exception/DuplicateSchemaException.php
@@ -17,7 +17,8 @@
 
 namespace Opis\JsonSchema\Exception;
 
-use stdClass, Throwable;
+use stdClass;
+use Throwable;
 
 class DuplicateSchemaException extends AbstractSchemaException
 {
@@ -38,7 +39,7 @@ class DuplicateSchemaException extends AbstractSchemaException
      * @param array $container
      * @param Throwable|null $previous
      */
-    public function __construct(string $id, stdClass $schema, array $container = [], Throwable $previous = null)
+    public function __construct(string $id, stdClass $schema, array $container = [], ?Throwable $previous = null)
     {
         $this->id = $id;
         $this->schema = $schema;

--- a/src/Exception/FilterNotFoundException.php
+++ b/src/Exception/FilterNotFoundException.php
@@ -34,7 +34,7 @@ class FilterNotFoundException extends AbstractSchemaException
      * @param string $filter
      * @param Throwable|null $previous
      */
-    public function __construct(string $type, string $filter, Throwable $previous = null)
+    public function __construct(string $type, string $filter, ?Throwable $previous = null)
     {
         $this->type = $type;
         $this->filter = $filter;

--- a/src/Exception/InvalidJsonPointerException.php
+++ b/src/Exception/InvalidJsonPointerException.php
@@ -30,7 +30,7 @@ class InvalidJsonPointerException extends AbstractSchemaException
      * @param string $pointer
      * @param Throwable|null $previous
      */
-    public function __construct(string $pointer, Throwable $previous = null)
+    public function __construct(string $pointer, ?Throwable $previous = null)
     {
         $this->pointer = $pointer;
         parent::__construct("Invalid JSON pointer: $pointer", 0, $previous);

--- a/src/Exception/InvalidSchemaDraftException.php
+++ b/src/Exception/InvalidSchemaDraftException.php
@@ -17,7 +17,8 @@
 
 namespace Opis\JsonSchema\Exception;
 
-use stdClass, Throwable;
+use stdClass;
+use Throwable;
 
 class InvalidSchemaDraftException extends AbstractSchemaException
 {
@@ -30,7 +31,7 @@ class InvalidSchemaDraftException extends AbstractSchemaException
      * @param stdClass $schema
      * @param Throwable|null $previous
      */
-    public function __construct(stdClass $schema, Throwable $previous = null)
+    public function __construct(stdClass $schema, ?Throwable $previous = null)
     {
         $this->schema = $schema;
         parent::__construct("Invalid '\$schema' property", 0, $previous);

--- a/src/Exception/InvalidSchemaException.php
+++ b/src/Exception/InvalidSchemaException.php
@@ -30,7 +30,7 @@ class InvalidSchemaException extends AbstractSchemaException
      * @param $schema
      * @param Throwable|null $previous
      */
-    public function __construct($schema, Throwable $previous = null)
+    public function __construct($schema, ?Throwable $previous = null)
     {
         $this->schema = $schema;
         $type = is_object($schema) ? get_class($schema) : gettype($schema);

--- a/src/Exception/InvalidSchemaIdException.php
+++ b/src/Exception/InvalidSchemaIdException.php
@@ -30,7 +30,7 @@ class InvalidSchemaIdException extends AbstractSchemaException
      * @param string $id
      * @param Throwable|null $previous
      */
-    public function __construct(string $id, Throwable $previous = null)
+    public function __construct(string $id, ?Throwable $previous = null)
     {
         $this->id = $id;
         parent::__construct("Invalid id '{$id}'", 0, $previous);

--- a/src/Exception/SchemaDraftNotSupportedException.php
+++ b/src/Exception/SchemaDraftNotSupportedException.php
@@ -17,7 +17,8 @@
 
 namespace Opis\JsonSchema\Exception;
 
-use stdClass, Throwable;
+use stdClass;
+use Throwable;
 
 class SchemaDraftNotSupportedException extends AbstractSchemaException
 {
@@ -34,7 +35,7 @@ class SchemaDraftNotSupportedException extends AbstractSchemaException
      * @param string $draft
      * @param Throwable|null $previous
      */
-    public function __construct(stdClass $schema, string $draft, Throwable $previous = null)
+    public function __construct(stdClass $schema, string $draft, ?Throwable $previous = null)
     {
         $this->schema = $schema;
         $this->draft = $draft;

--- a/src/Exception/SchemaKeywordException.php
+++ b/src/Exception/SchemaKeywordException.php
@@ -17,7 +17,8 @@
 
 namespace Opis\JsonSchema\Exception;
 
-use stdClass, Throwable;
+use stdClass;
+use Throwable;
 
 class SchemaKeywordException extends AbstractSchemaException
 {
@@ -39,7 +40,7 @@ class SchemaKeywordException extends AbstractSchemaException
      * @param string $message
      * @param Throwable|null $previous
      */
-    public function __construct(stdClass $schema, string $keyword, $value, string $message, Throwable $previous = null)
+    public function __construct(stdClass $schema, string $keyword, $value, string $message, ?Throwable $previous = null)
     {
         $this->schema = $schema;
         $this->keyword = $keyword;

--- a/src/Exception/SchemaNotFoundException.php
+++ b/src/Exception/SchemaNotFoundException.php
@@ -30,7 +30,7 @@ class SchemaNotFoundException extends AbstractSchemaException
      * @param string $id
      * @param Throwable|null $previous
      */
-    public function __construct(string $id, Throwable $previous = null)
+    public function __construct(string $id, ?Throwable $previous = null)
     {
         $this->id = $id;
         parent::__construct("Schema '{$id}' was not found or could not be loaded", 0, $previous);

--- a/src/Exception/UnknownMediaTypeException.php
+++ b/src/Exception/UnknownMediaTypeException.php
@@ -17,7 +17,8 @@
 
 namespace Opis\JsonSchema\Exception;
 
-use stdClass, Throwable;
+use stdClass;
+use Throwable;
 
 class UnknownMediaTypeException extends AbstractSchemaException
 {
@@ -31,7 +32,7 @@ class UnknownMediaTypeException extends AbstractSchemaException
     /**
      * @inheritDoc
      */
-    public function __construct(stdClass $schema, string $media, Throwable $previous = null)
+    public function __construct(stdClass $schema, string $media, ?Throwable $previous = null)
     {
         $this->schema = $schema;
         $this->media = $media;


### PR DESCRIPTION
There is some "Implicitly marking a parameter as nullable is deprecated since PHP 8.4" exceptions