### PR TITLE
chore(json-schema): add PHPStan assertions to `ValidationResult` helpers

### DIFF
--- a/src/ValidationResult.php
+++ b/src/ValidationResult.php
@@ -33,11 +33,17 @@ class ValidationResult
         return $this->error;
     }
 
+    /**
+     * @phpstan-assert-if-true null $this->error
+     */
     public function isValid(): bool
     {
         return $this->error === null;
     }
 
+    /**
+     * @phpstan-assert-if-true ValidationError $this->error
+     */
     public function hasError(): bool
     {
         return $this->error !== null;


### PR DESCRIPTION
Add `@phpstan-assert-if-true` annotations to `isValid()` and `hasError()`in ValidationResult.

This project does not run PHPStan itself, but these annotations improve type inference for projects that consume this package and do use PHPStan.